### PR TITLE
Add type to CSS links and fix meta tag

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,17 +1,15 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta encoding="utf-8">
+        <meta charset="UTF-8">
         <title>zerk</title>
-
-        <link href='https://fonts.googleapis.com/css?family=Crimson+Text:400,400italic,700,700italic' rel='stylesheet'>
-        <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400' rel='stylesheet'>
-        <link href='https://fonts.googleapis.com/css?family=Roboto:100,300' rel='stylesheet'>
+        <link href='https://fonts.googleapis.com/css?family=Crimson+Text:400,400italic,700,700italic' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Roboto:100,300' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="normalize.css">
         <link rel="stylesheet" href="style.css">
     </head>
     <body>
-        
         <a class="share-link"></a><i class="i-share"></i>
         <textarea id="input" class="code" placeholder="Loading ..."></textarea>
         <article id="output" class="markdown-body">


### PR DESCRIPTION
I started to see this error on Firefox for some reason:

```
The stylesheet https://rishav.io/zerk/normalize.css was not loaded because its MIME type, “text/html”, is not “text/css”.
The stylesheet https://rishav.io/zerk/style.css was not loaded because its MIME type, “text/html”, is not “text/css”.
```

Theoretically, `text/html` is not mandatory, but hopefully, adding it will fix the error.

Also, this is weirdly broking the website:
![image](https://user-images.githubusercontent.com/14128874/114707138-c33d7b00-9d21-11eb-8602-642e8dd69f99.png)

Thanks for this awesome website.